### PR TITLE
Add netlist to flowchart interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # SPICE-Net-Interpret
+
+This repository provides a simple Python script to parse a SPICE `.cir` netlist and generate a Graphviz flowchart of the circuit connections.
+
+## Usage
+
+```bash
+pip install graphviz
+python3 cir_to_flowchart.py example.cir output.dot
+```
+
+If no output path is given, the DOT representation is printed to standard output. Use Graphviz to render the DOT file to an image, e.g. `dot -Tpng output.dot -o output.png`.

--- a/cir_to_flowchart.py
+++ b/cir_to_flowchart.py
@@ -1,0 +1,54 @@
+import argparse
+import re
+from graphviz import Digraph
+
+
+def parse_netlist(text):
+    components = {}
+    nets = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith('*') or line.startswith(';'):
+            continue
+        if line.lower().startswith('.end'):
+            break
+        if line.startswith('.'):  # directive
+            continue
+        tokens = re.split(r'\s+', line)
+        if len(tokens) < 3:
+            continue
+        name = tokens[0]
+        node_tokens = tokens[1:3]
+        nets.update(node_tokens)
+        components[name] = node_tokens
+    return components, nets
+
+
+def build_graph(components):
+    dot = Digraph()
+    dot.attr('node', shape='box')
+    for comp, nodes in components.items():
+        dot.node(comp)
+        for node in nodes:
+            net_node = f"net_{node}"
+            dot.node(net_node, label=node, shape='ellipse')
+            dot.edge(comp, net_node)
+    return dot
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert SPICE .cir netlist to flowchart (graphviz dot).')
+    parser.add_argument('input', help='Path to .cir netlist file')
+    parser.add_argument('output', nargs='?', help='Output dot file path (optional)')
+    args = parser.parse_args()
+    with open(args.input) as f:
+        text = f.read()
+    components, nets = parse_netlist(text)
+    dot = build_graph(components)
+    if args.output:
+        dot.save(args.output)
+    else:
+        print(dot.source)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `cir_to_flowchart.py` to convert SPICE `.cir` files to Graphviz DOT
- document usage in README

## Testing
- `python3 -m py_compile cir_to_flowchart.py`

------
https://chatgpt.com/codex/tasks/task_e_685430a0b3c0832b98378021bad5e1af